### PR TITLE
Added `sudo: required` to travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
     - linux
     - osx
 
+sudo: required
+
 env:
     global:
         - PACKAGE="UnitTesting"


### PR DESCRIPTION
We need to specify `sudo: required`, or else TravisCI will use its container based infrastructure (for new repos), and will fail because it doesn't allow sudo.

I've filed an [APT source whitelist request](https://github.com/travis-ci/travis-ci/issues/3921). Once it has been approved, we can use the [apt addon](http://docs.travis-ci.com/user/apt/) instead of using `sudo apt-get ...`