### PR TITLE
pass encoding arg to out-file

### DIFF
--- a/sbin/appveyor.ps1
+++ b/sbin/appveyor.ps1
@@ -31,11 +31,7 @@ function Bootstrap {
     copy * -recurse -force "C:\st\Data\Packages\${env:PACKAGE}"
 
     new-item -itemtype directory "C:\st\Data\Packages\User" -force >$null
-    # "{`"update_check`": false }" | out-file -filepath "C:\st\Data\Packages\User\Preferences.sublime-settings"
-    # for no reason, sublime-text doesn't like the file created by out-file
-    $stream = [System.IO.StreamWriter] "C:\st\Data\Packages\User\Preferences.sublime-settings"
-    $stream.WriteLine("{`"update_check`": false}")
-    $stream.close()
+    "{`"update_check`": false }" | out-file -filepath "C:\st\Data\Packages\User\Preferences.sublime-settings" -encoding ascii
 
     if ( ${env:TAG} -eq $null ){
         # the latest tag


### PR DESCRIPTION
This should remove the need for creating a stream writer. By default, out-file uses UTF16 and ST doesn't like that.