### PR TITLE
Handle PackageControl Dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ env:
     matrix:
         - SUBLIME_TEXT_VERSION="2"
         - SUBLIME_TEXT_VERSION="3"
+        - PCDEPS="true"
+          SUBLIME_TEXT_VERSION="2"
+        - PCDEPS="true"
+          SUBLIME_TEXT_VERSION="3"
 
 install:
     - sh sbin/travis.sh bootstrap

--- a/sbin/run.py
+++ b/sbin/run.py
@@ -50,19 +50,23 @@ with open(jpath, 'w') as f:
     f.write(json.dumps(schedule, ensure_ascii=False, indent=True))
 
 # launch scheduler
-tasks = subprocess.check_output(['ps', 'xw']).decode('utf8')
-sublime_is_running = "Sublime" in tasks or "sublime_text" in tasks
+def sublime_is_running():
+    PIPE = subprocess.PIPE
+    out, err = subprocess.Popen(['pgrep','[s|S]ubl'], stdout=PIPE, stderr=PIPE).communicate()
+    return not err and len(out) > 0
 
-if not sublime_is_running:
+if not sublime_is_running():
     subprocess.Popen(["subl"])
-    startt = time.time()
-    while(not any([subl in task for subl in ["Sublime", "sublime_text"] for task in tasks])):
-        sys.stdout.write('.')
-        sys.stdout.flush()
-        if time.time()-startt > 60:
-            print("Timeout: Sublime Text is not responding")
-            sys.exit(1)
-        time.sleep(1)
+
+startt = time.time()
+while(not sublime_is_running()):
+    sys.stdout.write('.')
+    sys.stdout.flush()
+    if time.time()-startt > 60:
+        print("Timeout: Sublime Text is not responding")
+        sys.exit(1)
+    time.sleep(1)
+
 subprocess.Popen(["subl", "-b", "--command", "unit_testing_run_scheduler"])
 
 # wait until the file has something

--- a/sbin/run.py
+++ b/sbin/run.py
@@ -55,19 +55,18 @@ def sublime_is_running():
     out, err = subprocess.Popen(['pgrep','[s|S]ubl'], stdout=PIPE, stderr=PIPE).communicate()
     return not err and len(out) > 0
 
-if not sublime_is_running():
+if sublime_is_running():
+    subprocess.Popen(["subl", "-b", "--command", "unit_testing_run_scheduler"])
+else:
     subprocess.Popen(["subl"])
-
-startt = time.time()
-while(not sublime_is_running()):
-    sys.stdout.write('.')
-    sys.stdout.flush()
-    if time.time()-startt > 60:
-        print("Timeout: Sublime Text is not responding")
-        sys.exit(1)
-    time.sleep(1)
-
-subprocess.Popen(["subl", "-b", "--command", "unit_testing_run_scheduler"])
+    startt = time.time()
+    while(not sublime_is_running()):
+        sys.stdout.write('.')
+        sys.stdout.flush()
+        if time.time()-startt > 60:
+            print("Timeout: Sublime Text is not responding")
+            sys.exit(1)
+        time.sleep(1)
 
 # wait until the file has something
 startt = time.time()

--- a/sbin/run.py
+++ b/sbin/run.py
@@ -53,20 +53,17 @@ with open(jpath, 'w') as f:
 tasks = subprocess.check_output(['ps', 'xw']).decode('utf8')
 sublime_is_running = "Sublime" in tasks or "sublime_text" in tasks
 
-print("Running? %s" % sublime_is_running)
-if sublime_is_running:
-    subprocess.Popen(["subl", "-b", "--command", "unit_testing_run_scheduler"])
-else:
+if not sublime_is_running:
     subprocess.Popen(["subl"])
     startt = time.time()
-    while("Sublime" not in tasks and "sublime_text" not in task):
+    while(not any([subl in task for subl in ["Sublime", "sublime_text"] for task in tasks])):
         sys.stdout.write('.')
         sys.stdout.flush()
         if time.time()-startt > 60:
             print("Timeout: Sublime Text is not responding")
             sys.exit(1)
         time.sleep(1)
-    subprocess.Popen(["subl", "-b", "--command", "unit_testing_run_scheduler"])
+subprocess.Popen(["subl", "-b", "--command", "unit_testing_run_scheduler"])
 
 # wait until the file has something
 startt = time.time()

--- a/sbin/run.py
+++ b/sbin/run.py
@@ -53,10 +53,20 @@ with open(jpath, 'w') as f:
 tasks = subprocess.check_output(['ps', 'xw']).decode('utf8')
 sublime_is_running = "Sublime" in tasks or "sublime_text" in tasks
 
+print("Running? %s" % sublime_is_running)
 if sublime_is_running:
     subprocess.Popen(["subl", "-b", "--command", "unit_testing_run_scheduler"])
 else:
     subprocess.Popen(["subl"])
+    startt = time.time()
+    while("Sublime" not in tasks and "sublime_text" not in task):
+        sys.stdout.write('.')
+        sys.stdout.flush()
+        if time.time()-startt > 60:
+            print("Timeout: Sublime Text is not responding")
+            sys.exit(1)
+        time.sleep(1)
+    subprocess.Popen(["subl", "-b", "--command", "unit_testing_run_scheduler"])
 
 # wait until the file has something
 startt = time.time()

--- a/sbin/travis.sh
+++ b/sbin/travis.sh
@@ -54,6 +54,17 @@ Bootstrap() {
         fi
         git clone --quiet --depth 1 --branch $TAG https://github.com/randy3k/UnitTesting "$STP/UnitTesting"
     fi
+
+	STIP="${STP%/*}/Installed Packages"
+	if [ ! -d "$STIP" ]; then
+		echo creating sublime installed package directory
+		mkdir -p "$STIP"
+	fi
+
+	# Install PackageControl
+	PC_URL="https://packagecontrol.io/Package Control.sublime-package"
+	PC_PKG="${PC_URL##*/}"
+	curl "$PC_URL" -o "$STIP/$PC_PKG"
 }
 
 RunTests() {
@@ -79,6 +90,18 @@ RunTests() {
             sh -e /etc/init.d/xvfb start
         fi
     fi
+
+	# Install dependencies through Package Control
+	if [ -n $PCDEPS ]; then
+		subl -b --command satisfy_dependencies
+		sleep 10
+		subl -b --command upgrade_all_packages
+		sleep 10
+		subl -b --command install_local_dependency
+		sleep 10
+	fi
+
+	# Run tests
     UT="$STP/UnitTesting"
     if [ -z "$1" ]; then
         python "$UT/sbin/run.py" "$PACKAGE"

--- a/sbin/travis.sh
+++ b/sbin/travis.sh
@@ -156,7 +156,6 @@ RunTests() {
     fi
 }
 
-	echo "Command: $*"
 COMMAND=$1
 echo "Running command: ${COMMAND}"
 shift

--- a/sbin/travis.sh
+++ b/sbin/travis.sh
@@ -94,7 +94,6 @@ CloseSubl(){
 }
 
 CycleUntil() {
-	echo Opening Sublime until Package Control installs...
 	until eval "$1 2>/dev/null"; do
 		echo Opening...
 		OpenSubl
@@ -103,7 +102,7 @@ CycleUntil() {
 		TOUT=0
 		until eval "$1 2>/dev/null" || [ $TOUT -ge 30 ]; do
 			sleep 1
-			TOUT=$(( TOUT++ ))
+			TOUT=`expr $TOUT + 1`
 		done
 		if [ $TOUT -ge 30 ]; then
 			echo Timed out after 30s. Retrying...
@@ -143,13 +142,16 @@ RunTests() {
 
 	# Install dependencies through Package Control
 	if [ -n $PCDEPS ]; then
+		echo Installing Package Control...
+		CycleUntil "[ -f '$STP/User/Package Control.sublime-settings' ]"
+		echo Opening Sublime until Package Control installs...
 		CycleUntil "awk '/installed_packages/,/]/' \
 			'$STP/User/Package Control.sublime-settings' | grep -q 'Package Control'"
-		echo "Installing dependencies"
+		echo Installing dependencies...
 		subl -b --command install_local_dependency &
 		CycleUntil "! awk '/in_process_packages/,/]/' \
 			'$STP/User/Package Control.sublime-settings' | tail -n +2 | grep -q \""
-		echo "Finished installing dependencies"
+		echo Finished installing dependencies
 	fi
 
 	echo "Running tests now..."

--- a/sbin/travis.sh
+++ b/sbin/travis.sh
@@ -133,15 +133,8 @@ RunTests() {
 
 		echo Installing Package Control...
 		CycleUntil "[ -f '$STP/User/Package Control.sublime-settings' ] && $finished"
-
-		echo Opening Sublime until Package Control installs...
-		CycleUntil "[ -d '$STP/bz2' ] && $finished"
-
 		echo Installing dependencies...
-		OpenSubl -b --command install_local_dependency
-		sleep 5
-		CycleUntil "$finished"
-
+		CycleUntil "[ -d '$STP/bz2' ] && $finished"
 		echo Finished installing dependencies
 	fi
 

--- a/sbin/travis.sh
+++ b/sbin/travis.sh
@@ -120,7 +120,7 @@ RunTests() {
 		echo "Cycling ST"
 		CycleSubl
 		echo "Installing dependencies"
-		subl -b --command install_local_dependency
+		subl -b --command install_local_dependency &
 		sleep 20
 		echo "Done installing dependencies... hopefully"
 	fi

--- a/sbin/travis.sh
+++ b/sbin/travis.sh
@@ -54,17 +54,6 @@ Bootstrap() {
         fi
         git clone --quiet --depth 1 --branch $TAG https://github.com/randy3k/UnitTesting "$STP/UnitTesting"
     fi
-
-	STIP="${STP%/*}/Installed Packages"
-	if [ ! -d "$STIP" ]; then
-		echo creating sublime installed package directory
-		mkdir -p "$STIP"
-	fi
-
-	# Install PackageControl
-	PC_URL="https://packagecontrol.io/Package Control.sublime-package"
-	PC_PKG="${PC_URL##*/}"
-	curl "$PC_URL" -o "$STIP/$PC_PKG"
 }
 
 OpenSubl() {
@@ -127,6 +116,18 @@ RunTests() {
 
 	# Install dependencies through Package Control
 	if [ -n $PCDEPS ]; then
+		STIP="${STP%/*}/Installed Packages"
+		if [ ! -d "$STIP" ]; then
+			echo creating sublime installed package directory
+			mkdir -p "$STIP"
+		fi
+	
+		# Install PackageControl
+		PC_URL="https://packagecontrol.io/Package Control.sublime-package"
+		PC_PKG="${PC_URL##*/}"
+		curl "$PC_URL" -o "$STIP/$PC_PKG"
+
+		# Cycle ST to complete installation
 		finished="! awk '/in_process_packages/,/]/' \
 			'$STP/User/Package Control.sublime-settings' | tail -n +2 | grep -q \\\""
 

--- a/sbin/travis.sh
+++ b/sbin/travis.sh
@@ -81,7 +81,7 @@ CycleSubl() {
             sleep 2
         fi
     else
-		subl
+		subl &
 		sleep 15
 		pkill subl
 		sleep 2

--- a/sbin/travis.sh
+++ b/sbin/travis.sh
@@ -115,7 +115,7 @@ RunTests() {
     fi
 
 	# Install dependencies through Package Control
-	if [ -n $PCDEPS ]; then
+	if [ -n "$PCDEPS" ]; then
 		STIP="${STP%/*}/Installed Packages"
 		if [ ! -d "$STIP" ]; then
 			echo creating sublime installed package directory

--- a/sbin/travis.sh
+++ b/sbin/travis.sh
@@ -71,28 +71,12 @@ OpenSubl() {
 	# Do not open if already open
 	ps aux | grep -iqE 'subl[^/]*(\s|$)' && return
 
-    if [ $(uname) = 'Darwin' ]; then
-        if [ $SUBLIME_TEXT_VERSION -eq 2 ]; then
-            open "$HOME/Applications/Sublime Text 2.app $@"
-        elif [ $SUBLIME_TEXT_VERSION -eq 3 ]; then
-            open "$HOME/Applications/Sublime Text.app $@"
-        fi
-    else
-		subl $@ &
-	fi
+	subl $@ &
 	sleep 2
 }
 
 CloseSubl(){
-    if [ $(uname) = 'Darwin' ]; then
-        if [ $SUBLIME_TEXT_VERSION -eq 2 ]; then
-            osascript -e 'tell application "Sublime Text 2" to quit' || true
-        elif [ $SUBLIME_TEXT_VERSION -eq 3 ]; then
-            osascript -e 'tell application "Sublime Text" to quit' || true
-        fi
-    else
-		pkill subl
-	fi
+	pkill -n '[sS]ubl'
 	sleep 2
 }
 
@@ -171,6 +155,7 @@ RunTests() {
     fi
 }
 
+	echo "Command: $*"
 COMMAND=$1
 echo "Running command: ${COMMAND}"
 shift

--- a/sbin/travis.sh
+++ b/sbin/travis.sh
@@ -86,9 +86,9 @@ OpenSubl() {
 CloseSubl(){
     if [ $(uname) = 'Darwin' ]; then
         if [ $SUBLIME_TEXT_VERSION -eq 2 ]; then
-            osascript -e 'tell application "Sublime Text 2" to quit'
+            osascript -e 'tell application "Sublime Text 2" to quit' || true
         elif [ $SUBLIME_TEXT_VERSION -eq 3 ]; then
-            osascript -e 'tell application "Sublime Text" to quit'
+            osascript -e 'tell application "Sublime Text" to quit' || true
         fi
     else
 		pkill subl
@@ -125,12 +125,12 @@ RunTests() {
         if [ $SUBLIME_TEXT_VERSION -eq 2 ]; then
             open "$HOME/Applications/Sublime Text 2.app"
             sleep 2
-            osascript -e 'tell application "Sublime Text 2" to quit'
+            osascript -e 'tell application "Sublime Text 2" to quit' || true
             sleep 2
         elif [ $SUBLIME_TEXT_VERSION -eq 3 ]; then
             open "$HOME/Applications/Sublime Text.app"
             sleep 2
-            osascript -e 'tell application "Sublime Text" to quit'
+            osascript -e 'tell application "Sublime Text" to quit' || true
             sleep 2
         fi
     else
@@ -144,7 +144,7 @@ RunTests() {
 	# Install dependencies through Package Control
 	if [ -n $PCDEPS ]; then
 		finished="! awk '/in_process_packages/,/]/' \
-			'$STP/User/Package Control.sublime-settings' | tail -n +2 | grep -q \""
+			'$STP/User/Package Control.sublime-settings' | tail -n +2 | grep -q \\\""
 
 		echo Installing Package Control...
 		CycleUntil "[ -f '$STP/User/Package Control.sublime-settings' ] && $finished"

--- a/sbin/travis.sh
+++ b/sbin/travis.sh
@@ -67,6 +67,28 @@ Bootstrap() {
 	curl "$PC_URL" -o "$STIP/$PC_PKG"
 }
 
+CycleSubl() {
+    if [ $(uname) = 'Darwin' ]; then
+        if [ $SUBLIME_TEXT_VERSION -eq 2 ]; then
+            open "$HOME/Applications/Sublime Text 2.app"
+            sleep 15
+            osascript -e 'tell application "Sublime Text 2" to quit'
+            sleep 2
+        elif [ $SUBLIME_TEXT_VERSION -eq 3 ]; then
+            open "$HOME/Applications/Sublime Text.app"
+            sleep 15
+            osascript -e 'tell application "Sublime Text" to quit'
+            sleep 2
+        fi
+    else
+		subl
+		sleep 15
+		pkill subl
+		sleep 2
+	fi
+
+}
+
 RunTests() {
     if [ $(uname) = 'Darwin' ]; then
         STP="$HOME/Library/Application Support/Sublime Text $SUBLIME_TEXT_VERSION/Packages"
@@ -93,13 +115,17 @@ RunTests() {
 
 	# Install dependencies through Package Control
 	if [ -n $PCDEPS ]; then
-		subl -b --command satisfy_dependencies
-		sleep 10
-		subl -b --command upgrade_all_packages
-		sleep 10
+		echo "Cycling ST"
+		CycleSubl
+		echo "Cycling ST"
+		CycleSubl
+		echo "Installing dependencies"
 		subl -b --command install_local_dependency
-		sleep 10
+		sleep 20
+		echo "Done installing dependencies... hopefully"
 	fi
+
+	echo "Running tests now..."
 
 	# Run tests
     UT="$STP/UnitTesting"


### PR DESCRIPTION
My plugin has some PC dependencies, so I wanted the capability to automatically satisfy them. There's some pretty complex logic involved, so I thought it would be easier to install PC and let it handle them. Still, this wasn't easy, because Sublime needs to restart during PC installation. After a whole day of fiddling, I got it to work on all 4 platform/version combos.

This code is probably pretty fragile, so I'd be happy to receive some ideas and feedback, and if anyone thinks this is useful. To use it, just add a global environment variable PCDEPS=true in `.travis.yml`.