### PR TITLE
Add command to reopen output panel.

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -18,5 +18,9 @@
   {
     "caption": "UnitTesting: Test Current File",
     "command": "unit_testing_current_file"
+  },
+  {
+    "caption": "UnitTesting: Show Output Panel",
+    "command": "unit_testing_show_output"
   }
 ]

--- a/unittesting/__init__.py
+++ b/unittesting/__init__.py
@@ -1,5 +1,5 @@
 from .core import DeferrableTestCase
-from .utils import OutputPanelInsertCommand
+from .utils import OutputPanelInsertCommand, UnitTestingShowOutputCommand
 from .scheduler import UnitTestingRunSchedulerCommand, run_scheduler
 from .test_package import UnitTestingCommand
 from .test_coverage import UnitTestingCoverageCommand
@@ -12,6 +12,7 @@ from . import helpers
 
 __all__ = [
     "DeferrableTestCase", "OutputPanelInsertCommand",
+    "UnitTestingShowOutputCommand",
     "UnitTestingRunSchedulerCommand", "run_scheduler",
     "UnitTestingCommand",
     "UnitTestingCoverageCommand",

--- a/unittesting/utils/__init__.py
+++ b/unittesting/utils/__init__.py
@@ -1,5 +1,6 @@
 from .json_file import JsonFile
-from .output_panel import OutputPanelInsertCommand, OutputPanel
+from .output_panel import OutputPanelInsertCommand, OutputPanel, \
+    UnitTestingShowOutputCommand
 from . import settings as UTSetting
 from .progress_bar import ProgressBar
 import sublime
@@ -13,6 +14,7 @@ else:
 __all__ = [
     "JsonFile",
     "OutputPanelInsertCommand",
+    "UnitTestingShowOutputCommand",
     "OutputPanel",
     "UTSetting",
     "ProgressBar",

--- a/unittesting/utils/output_panel.py
+++ b/unittesting/utils/output_panel.py
@@ -13,6 +13,12 @@ class OutputPanelInsertCommand(sublime_plugin.TextCommand):
         self.view.show(self.view.size())
 
 
+class UnitTestingShowOutputCommand(sublime_plugin.WindowCommand):
+
+    def run(self):
+        self.window.run_command('show_panel', {'panel': 'output.UnitTesting'})
+
+
 class OutputPanel:
 
     def __init__(

--- a/ut.py
+++ b/ut.py
@@ -25,6 +25,7 @@ from unittesting import (
     UnitTestingCurrentProjectCommand,
     UnitTestingCurrentProjectCoverageCommand,
     UnitTestingReloadCurrentProjectCommand,
+    UnitTestingShowOutputCommand,
     UnitTestingSyntaxCommand,
     OutputPanelInsertCommand,
     run_scheduler


### PR DESCRIPTION
If there are errors, I often need to reopen the unittesting output panel to check them while working.  This adds a command to reopen the panel.  