### PR TITLE
Add ColorSchemeUnit support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
       fi
 
 install:
-    - sh sbin/travis.sh bootstrap
+    - sh sbin/travis.sh bootstrap --with-color-scheme-unit
     - if [ "$PCINSTALL" == true ]; then sh sbin/travis.sh install_package_control; fi
 
 script:

--- a/sbin/run_tests.py
+++ b/sbin/run_tests.py
@@ -14,10 +14,12 @@ import optparse
 
 parser = optparse.OptionParser()
 parser.add_option('--syntax-test', action="store_true", default=False)
+parser.add_option('--color-scheme-test', action="store_true", default=False)
 parser.add_option('--coverage', action="store_true", default=False)
 options, remainder = parser.parse_args()
 
 syntax_test = options.syntax_test
+color_scheme_test = options.color_scheme_test
 coverage = options.coverage
 package = remainder[0] if len(remainder) > 0 else "UnitTesting"
 
@@ -50,12 +52,18 @@ try:
 except:
     schedule = []
 if not any([s['package'] == package for s in schedule]):
-    schedule.append({
+    schedule_info = {
         'package': package,
         'output': outfile,
         'syntax_test': syntax_test,
+        'color_scheme_test': color_scheme_test,
         'coverage': coverage
-    })
+    }
+    print('Schedule:')
+    for k, v in schedule_info.items():
+        print('  %s: %s' % (k, v))
+
+    schedule.append(schedule_info)
 with open(jpath, 'w') as f:
     f.write(json.dumps(schedule, ensure_ascii=False, indent=True))
 
@@ -69,18 +77,19 @@ else:
     subprocess.Popen(["subl"])
 
 # wait until the file has something
+print("Wait for Sublime Text response")
 startt = time.time()
 while (not os.path.exists(outfile) or os.stat(outfile).st_size == 0):
     sys.stdout.write('.')
     sys.stdout.flush()
-    if time.time()-startt > 60:
+    if time.time() - startt > 60:
         print("Timeout: Sublime Text is not responding")
         sys.exit(1)
     time.sleep(1)
-
-print("\nstart to read output")
+print("")
 
 # todo: use notification instead of polling
+print("Start to read output...")
 with open(outfile, 'r') as f:
     while True:
         where = f.tell()

--- a/sbin/travis.sh
+++ b/sbin/travis.sh
@@ -27,10 +27,16 @@ Bootstrap() {
         fi
     fi
 
+    # Disable warnings about detached HEAD
+    # https://stackoverflow.com/questions/36794501
+    git config --global advice.detachedHead false
+
     UT_PATH="$STP/UnitTesting"
     if [ ! -d "$UT_PATH" ]; then
 
-        UT_URL="https://github.com/randy3k/UnitTesting"
+        if [ -z $UT_URL ]; then
+            UT_URL="https://github.com/randy3k/UnitTesting"
+        fi
 
         if [ -z $UNITTESTING_TAG ]; then
             if [ $SUBLIME_TEXT_VERSION -eq 2 ]; then
@@ -45,6 +51,8 @@ Bootstrap() {
 
         echo "download UnitTesting tag: $UNITTESTING_TAG"
         git clone --quiet --depth 1 --branch $UNITTESTING_TAG "$UT_URL" "$UT_PATH"
+        git -C "$UT_PATH" rev-parse HEAD
+        echo
     fi
 
     COV_PATH="$STP/coverage"
@@ -61,7 +69,31 @@ Bootstrap() {
 
         echo "download sublime-coverage tag: $COVERAGE_TAG"
         git clone --quiet --depth 1 --branch $COVERAGE_TAG "$COV_URL" "$COV_PATH"
+        git -C "$COV_PATH" rev-parse HEAD
+        echo
         rm -rf "$COV_PATH/.git"
+    fi
+
+    if [ "$1" = "--with-color-scheme-unit" ]; then
+        shift
+        CSU_PATH="$STP/ColorSchemeUnit"
+        if [ "$SUBLIME_TEXT_VERSION" -eq 3 ] && [ ! -d "$CSU_PATH" ]; then
+
+            CSU="https://github.com/gerardroche/sublime-color-scheme-unit"
+
+            if [ -z $COLOR_SCHEME_UNIT_TAG ]; then
+                # latest tag
+                COLOR_SCHEME_UNIT_TAG=$(git ls-remote --tags "$CSU" |
+                      sed 's|.*/\(.*\)$|\1|' | grep -v '\^' |
+                      sort -t. -k1,1nr -k2,2nr -k3,3nr | head -n1)
+            fi
+
+            echo "download ColorSchemeUnit tag: $COLOR_SCHEME_UNIT_TAG"
+            git clone --quiet --depth 1 --branch $COLOR_SCHEME_UNIT_TAG "$CSU" "$CSU_PATH"
+            git -C "$CSU_PATH" rev-parse HEAD
+            echo
+            rm -rf "$CSU_PATH/.git"
+        fi
     fi
 
     sh "$STP/UnitTesting/sbin/install_sublime_text.sh"
@@ -83,18 +115,21 @@ RunTests() {
     if [ "$TRAVIS_OS_NAME" = "linux" ] && [ -z $DISPLAY ]; then
         export DISPLAY=:99.0
         sh -e /etc/init.d/xvfb start || true
+        # The above statement prints a status message
+        # but doesn't append a newline on the end.
+        echo ""
     fi
 
     if [ -z "$1" ]; then
         python "$STP/UnitTesting/sbin/run_tests.py" "$PACKAGE"
     else
-        python "$STP/UnitTesting/sbin/run_tests.py" "$1" "$PACKAGE"
+        python "$STP/UnitTesting/sbin/run_tests.py" "$@" "$PACKAGE"
     fi
 }
 
 COMMAND=$1
-echo "Running command: ${COMMAND}"
 shift
+echo "Running command: ${COMMAND} $@"
 case $COMMAND in
     "bootstrap")
         Bootstrap "$@"
@@ -107,5 +142,8 @@ case $COMMAND in
         ;;
     "run_syntax_tests")
         RunTests "--syntax-test" "$@"
+        ;;
+    "run_color_scheme_tests")
+        RunTests "--color-scheme-test" "$@"
         ;;
 esac

--- a/tests/_ColorScheme_Failure/color_scheme_test.html
+++ b/tests/_ColorScheme_Failure/color_scheme_test.html
@@ -1,0 +1,22 @@
+<!-- COLOR SCHEME TEST "UnitTesting/tests/_ColorScheme_Failure/failure.tmTheme" "HTML" -->
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Title</title>
+<!--    ^ fg=#000000 bg=#000000 fs= -->
+<!--    ^ fg=#000000 bg=#000000 -->
+<!--    ^ fg=#000000 fs=italic -->
+<!--    ^ fg=#000000 -->
+<!--    ^ bg=#000000 -->
+<!--    ^ fs=italic -->
+
+        <!-- x -->
+<!--    ^^^^ fg=#000000 fs= -->
+<!--         ^ fg=#000000 fs= -->
+<!--           ^^^ fg=#000000 fs= -->
+
+    </head>
+    <body>
+    </body>
+</html>

--- a/tests/_ColorScheme_Failure/failure.tmTheme
+++ b/tests/_ColorScheme_Failure/failure.tmTheme
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>name</key>
+        <string>UnitTesting Color Scheme</string>
+        <key>settings</key>
+        <array>
+            <dict>
+                <key>settings</key>
+                <dict>
+                    <key>background</key>
+                    <string>#222222</string>
+                    <key>foreground</key>
+                    <string>#eeeeee</string>
+                    <key>lineHighlight</key>
+                    <string>#cccccc88</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>scope</key>
+                <string>comment</string>
+                <key>settings</key>
+                <dict>
+                    <key>foreground</key>
+                    <string>#cccccc</string>
+                </dict>
+            </dict>
+        </array>
+    </dict>
+</plist>

--- a/tests/_ColorScheme_Success/color_scheme_test.html
+++ b/tests/_ColorScheme_Success/color_scheme_test.html
@@ -1,0 +1,17 @@
+<!-- COLOR SCHEME TEST "UnitTesting/tests/_ColorScheme_Success/success.tmTheme" "HTML" -->
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Title</title>
+<!--    ^^^^^^^^^^^^^^^^^^^^ fg=#eeeeee bg=#222222 fs= -->
+
+        <!-- x -->
+<!--    ^^^^ fg=#cccccc fs= -->
+<!--         ^ fg=#cccccc fs= -->
+<!--           ^^^ fg=#cccccc fs= -->
+
+    </head>
+    <body>
+    </body>
+</html>

--- a/tests/_ColorScheme_Success/success.tmTheme
+++ b/tests/_ColorScheme_Success/success.tmTheme
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>name</key>
+        <string>UnitTesting Color Scheme</string>
+        <key>settings</key>
+        <array>
+            <dict>
+                <key>settings</key>
+                <dict>
+                    <key>background</key>
+                    <string>#222222</string>
+                    <key>foreground</key>
+                    <string>#eeeeee</string>
+                    <key>lineHighlight</key>
+                    <string>#cccccc88</string>
+                </dict>
+            </dict>
+            <dict>
+                <key>scope</key>
+                <string>comment</string>
+                <key>settings</key>
+                <dict>
+                    <key>foreground</key>
+                    <string>#cccccc</string>
+                </dict>
+            </dict>
+        </array>
+    </dict>
+</plist>

--- a/tests/test_3141596.py
+++ b/tests/test_3141596.py
@@ -38,7 +38,7 @@ def cleanup_package(package):
         pass
 
 
-def perpare_package(package, output=None, syntax_test=False, delay=None):
+def perpare_package(package, output=None, syntax_test=False, color_scheme_test=False, delay=None):
     def wrapper(func):
         @wraps(func)
         def real_wrapper(self):
@@ -60,6 +60,9 @@ def perpare_package(package, output=None, syntax_test=False, delay=None):
             if syntax_test:
                 sublime.run_command(
                     "unit_testing_syntax", {"package": package, "output": outfile})
+            elif color_scheme_test:
+                sublime.run_command(
+                    "unit_testing_color_scheme", {"package": package, "output": outfile})
             else:
                 sublime.run_command(
                     "unit_testing", {"package": package, "output": outfile})
@@ -135,6 +138,22 @@ class TestSyntax(DeferrableTestCase):
     @perpare_package("_Syntax_Error", syntax_test=True, delay=1000)
     def test_error_syntax(self, txt):
         m = re.search('^ERROR: No syntax_test', txt, re.MULTILINE)
+        self.assertTrue(hasattr(m, "group"))
+
+
+class TestColorScheme(DeferrableTestCase):
+
+    def tearDown(self):
+        UTSetting.set("recent-package", "UnitTesting")
+
+    @perpare_package("_ColorScheme_Failure", color_scheme_test=True, delay=1000)
+    def test_fail_color_scheme(self, txt):
+        m = re.search('^There were 14 failures:$', txt, re.MULTILINE)
+        self.assertTrue(hasattr(m, "group"))
+
+    @perpare_package("_ColorScheme_Success", color_scheme_test=True, delay=1000)
+    def test_success_color_scheme(self, txt):
+        m = re.search('^OK', txt, re.MULTILINE)
         self.assertTrue(hasattr(m, "group"))
 
 

--- a/unittesting/__init__.py
+++ b/unittesting/__init__.py
@@ -5,6 +5,7 @@ from .test_coverage import UnitTestingCoverageCommand
 from .test_current import UnitTestingCurrentFileCommand, UnitTestingCurrentPackageCommand, \
     UnitTestingCurrentPackageCoverageCommand
 from .test_syntax import UnitTestingSyntaxCommand
+from .test_color_scheme import UnitTestingColorSchemeCommand
 from . import helpers
 
 
@@ -16,5 +17,6 @@ __all__ = [
     "UnitTestingCurrentFileCommand",
     "UnitTestingCurrentPackageCommand",
     "UnitTestingCurrentPackageCoverageCommand",
-    "UnitTestingSyntaxCommand"
+    "UnitTestingSyntaxCommand",
+    "UnitTestingColorSchemeCommand"
 ]

--- a/unittesting/scheduler.py
+++ b/unittesting/scheduler.py
@@ -11,11 +11,18 @@ class Unit:
     def __init__(self, s):
         self.package = s['package']
         self.output = s['output'] if 'output' in s else None
-        if 'syntax_test' in s and sublime.version() >= "3000":
+
+        if 'syntax_test' in s and int(sublime.version()) >= 3000:
             self.syntax_test = s['syntax_test']
         else:
             self.syntax_test = False
-        if 'coverage' in s and sublime.version() >= "3103":
+
+        if 'color_scheme_test' in s and int(sublime.version()) >= 3000:
+            self.color_scheme_test = s['color_scheme_test']
+        else:
+            self.color_scheme_test = False
+
+        if 'coverage' in s and int(sublime.version()) >= 3103:
             self.coverage = s['coverage']
         else:
             self.coverage = False
@@ -23,6 +30,11 @@ class Unit:
     def run(self):
         if self.syntax_test:
             sublime.run_command("unit_testing_syntax", {
+                "package": self.package,
+                "output": self.output
+            })
+        elif self.color_scheme_test:
+            sublime.run_command("unit_testing_color_scheme", {
                 "package": self.package,
                 "output": self.output
             })

--- a/unittesting/test_color_scheme.py
+++ b/unittesting/test_color_scheme.py
@@ -1,0 +1,31 @@
+import sublime
+from sublime_plugin import ApplicationCommand
+from .mixin import UnitTestingMixin
+
+try:
+    from ColorSchemeUnit.lib.runner import ColorSchemeUnit
+except:
+    print('ColorSchemeUnit runner could not be imported')
+
+
+class UnitTestingColorSchemeCommand(ApplicationCommand, UnitTestingMixin):
+
+    def run(self, package=None, **kargs):
+        if not package:
+            return
+
+        window = sublime.active_window()
+        settings = self.load_settings(package, **kargs)
+        stream = self.load_stream(package, settings["output"])
+
+        # Make sure at least one file from the
+        # package opened for ColorSchemeUnit.
+        tests = sublime.find_resources("color_scheme_test*")
+
+        if package != "__all__":
+            tests = [t for t in tests if t.startswith("Packages/%s/" % package)]
+
+        if tests:
+            window.open_file(sublime.packages_path().rstrip('Packages') + tests[0])
+
+        ColorSchemeUnit(window).run(output=stream)

--- a/ut.py
+++ b/ut.py
@@ -24,6 +24,7 @@ from unittesting import (
     UnitTestingCurrentPackageCommand,
     UnitTestingCurrentPackageCoverageCommand,
     UnitTestingSyntaxCommand,
+    UnitTestingColorSchemeCommand,
     run_scheduler
 )
 


### PR DESCRIPTION
ColorSchemeUnit is a testing framework for Sublime Text color schemes:

https://github.com/gerardroche/sublime-color-scheme-unit

Example usage:

https://github.com/gerardroche/sublime-monokai-free/blob/master/.travis.yml

There are several issues of note about the implementation:

* The bootstrap must be call with the option `--with-color-scheme-unit`
option. The reason for this is to avoid unnecessary download of the
plugin for test suites that don't test any color schemes.

* Several log message format issues have been fixed.

* An edge-case issue where all arguments are not passed to the
`run_tests.py` script has been fixed.

Closes #59