### PR TITLE
Use ColorSchemeunit new run with package API

### DIFF
--- a/unittesting/test_color_scheme.py
+++ b/unittesting/test_color_scheme.py
@@ -19,8 +19,6 @@ class UnitTestingColorSchemeCommand(ApplicationCommand, UnitTestingMixin):
         settings = self.load_unittesting_settings(package, **kargs)
         stream = self.load_stream(package, settings["output"])
 
-        # Make sure at least one file from the
-        # package opened for ColorSchemeUnit.
         tests = sublime.find_resources("color_scheme_test*")
         tests = [t for t in tests if t.startswith("Packages/%s/" % package)]
 
@@ -35,7 +33,15 @@ class UnitTestingColorSchemeCommand(ApplicationCommand, UnitTestingMixin):
         stream.write("Running ColorSchemeUnit\n")
         stream.flush()
 
-        view = window.open_file(sublime.packages_path().rstrip('Packages') + tests[0])
-        view.set_scratch(True)
+        result = ColorSchemeUnit(window).run(output=stream, package=package, async=False)
 
-        ColorSchemeUnit(window).run(output=stream)
+        if result:
+            stream.write('\n')
+            stream.write("OK.\n")
+        else:
+            stream.write('\n')
+            stream.write("FAILED.\n")
+
+        stream.write("\n")
+        stream.write(DONE_MESSAGE)
+        stream.close()


### PR DESCRIPTION
Re: https://github.com/gerardroche/sublime-color-scheme-unit/issues/18

The new API allows to run with package name so Unittesting doesn't need
to open any files before running the tests.

I also added an async parameter which allows to run the tests in non
async mode and get the result of the tests, True for pass and False for
fail. This allows Unittesting to handle printing the OK, FAILED and DONE
messsages.