### PR TITLE
avoid blocking the main thread on MacOS

### DIFF
--- a/sbin/run_tests.py
+++ b/sbin/run_tests.py
@@ -78,8 +78,8 @@ if os.path.exists(schedule_target):
 if not os.path.exists(schedule_target):
     shutil.copyfile(schedule_source, schedule_target)
 
-# launch sublime text
-subprocess.Popen(["subl"])
+# launch sublime text without blocking the main thread
+subprocess.Popen(["subl &"], shell=True)
 
 # wait until the file has something
 print("Wait for Sublime Text response")


### PR DESCRIPTION
Calling `subl` in run_tests.py will block the main thread on MacOS.

Verified on Bitbucket Pipelines (a long time ago) and Visual
Studio Team Services (VSTS) CI.

Using `subl &` fixes the issue at least in VSTS CI.